### PR TITLE
Allow to pass null as cvvSelector, cardTypeSelector parameter

### DIFF
--- a/src/creditly.js
+++ b/src/creditly.js
@@ -192,8 +192,6 @@ var Creditly = (function() {
       var creditCard = function(selector, data) {
         var rawNumber = document.querySelector(data["creditCardNumberSelector"]).value;
         var number = rawNumber.trim().replace(/\D/g, "");
-        var rawSecurityCode = document.querySelector(data["cvvSelector"]).value;
-        var securityCode = rawSecurityCode.trim().replace(/\D/g, "");
         var messages = [];
         var isValid = true;
         var selectors = [];
@@ -204,10 +202,15 @@ var Creditly = (function() {
           isValid = false;
         }
 
-        if (!isValidSecurityCode(isAmericanExpress(number), securityCode)) {
-          messages.push(data["message"]["security_code"]);
-          selectors.push(data["cvvSelector"]);
-          isValid = false;
+        if (data.cvvSelector) {
+          var rawSecurityCode = document.querySelector(data["cvvSelector"]).value;
+          var securityCode = rawSecurityCode.trim().replace(/\D/g, "");
+
+          if (!isValidSecurityCode(isAmericanExpress(number), securityCode)) {
+            messages.push(data["message"]["security_code"]);
+            selectors.push(data["cvvSelector"]);
+            isValid = false;
+          }
         }
 
         result = {
@@ -426,8 +429,12 @@ var Creditly = (function() {
 
     ExpirationInput.createExpirationInput(expirationSelector);
     NumberInput.createNumberInput(creditCardNumberSelector);
-    CvvInput.createCvvInput(cvvSelector, creditCardNumberSelector);
-    CardTypeListener.changeCardType(creditCardNumberSelector, cardTypeSelector);
+    if (cvvSelector) {
+      CvvInput.createCvvInput(cvvSelector, creditCardNumberSelector);
+    }
+    if (cardTypeSelector) {
+      CardTypeListener.changeCardType(creditCardNumberSelector, cardTypeSelector);
+    }
 
     return {
       validate: function() {


### PR DESCRIPTION
TypeError is thrown when null is passed as cvvSelector.
So, allow to pass null as cvvSelector and cardTypeSelector parameter.

``` javascript
var creditly = Creditly.initialize(
    '.creditly-wrapper .expiration-month-and-year',
    '.creditly-wrapper .credit-card-number',
    null,
    '.creditly-wrapper .card-type'
);
```
